### PR TITLE
experimental daemon plugin for 9P2000.L support (writable portions)

### DIFF
--- a/plugin/plugins/filesystem/filesystem_test.go
+++ b/plugin/plugins/filesystem/filesystem_test.go
@@ -26,6 +26,8 @@ func TestAll(t *testing.T) {
 	t.Run("RootFS", func(t *testing.T) { testRootFS(ctx, t, core) })
 	t.Run("PinFS", func(t *testing.T) { testPinFS(ctx, t, core) })
 	t.Run("IPFS", func(t *testing.T) { testIPFS(ctx, t, core) })
+	t.Run("MFS", func(t *testing.T) { testMFS(ctx, t, core) })
+	t.Run("IPNS", func(t *testing.T) { testIPNS(ctx, t, core) })
 
 	pluginEnv := &plugin.Environment{Config: defaultConfig()}
 	t.Run("Plugin", func(t *testing.T) { testPlugin(t, pluginEnv, core) })

--- a/plugin/plugins/filesystem/ipns_test.go
+++ b/plugin/plugins/filesystem/ipns_test.go
@@ -1,0 +1,13 @@
+package filesystem
+
+import (
+	"context"
+	"testing"
+
+	fsnodes "github.com/ipfs/go-ipfs/plugin/plugins/filesystem/nodes"
+	coreiface "github.com/ipfs/interface-go-ipfs-core"
+)
+
+func testIPNS(ctx context.Context, t *testing.T, core coreiface.CoreAPI) {
+	t.Run("Baseline", func(t *testing.T) { baseLine(ctx, t, core, fsnodes.IPNSAttacher) })
+}

--- a/plugin/plugins/filesystem/mfs_test.go
+++ b/plugin/plugins/filesystem/mfs_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	fsnodes "github.com/ipfs/go-ipfs/plugin/plugins/filesystem/nodes"
 	coreiface "github.com/ipfs/interface-go-ipfs-core"
 )
 
 func testMFS(ctx context.Context, t *testing.T, core coreiface.CoreAPI) {
-	t.Run("Baseline", func(t *testing.T) { baseLine(ctx, t, core, fsnodes.MFSAttacher) })
+	//TODO: init root CID
+	//t.Run("Baseline", func(t *testing.T) { baseLine(ctx, t, core, fsnodes.MFSAttacher) })
 }

--- a/plugin/plugins/filesystem/mfs_test.go
+++ b/plugin/plugins/filesystem/mfs_test.go
@@ -1,0 +1,13 @@
+package filesystem
+
+import (
+	"context"
+	"testing"
+
+	fsnodes "github.com/ipfs/go-ipfs/plugin/plugins/filesystem/nodes"
+	coreiface "github.com/ipfs/interface-go-ipfs-core"
+)
+
+func testMFS(ctx context.Context, t *testing.T, core coreiface.CoreAPI) {
+	t.Run("Baseline", func(t *testing.T) { baseLine(ctx, t, core, fsnodes.MFSAttacher) })
+}

--- a/plugin/plugins/filesystem/nodes/keyfs.go
+++ b/plugin/plugins/filesystem/nodes/keyfs.go
@@ -162,7 +162,7 @@ func (kd *KeyFS) Step(keyName string) (fsutils.WalkRef, error) {
 			opts := []nodeopts.AttachOption{
 				nodeopts.Parent(kd),
 				nodeopts.MFSPublish(ipnsPublisher(key.Name(), offlineAPI(kd.core).Name())),
-				nodeopts.MFSRoot(&cid),
+				nodeopts.MFSRoot(cid),
 				nodeopts.Logger(logging.Logger("IPNS-Key")),
 			}
 

--- a/plugin/plugins/filesystem/nodes/keyfs.go
+++ b/plugin/plugins/filesystem/nodes/keyfs.go
@@ -2,14 +2,21 @@ package fsnodes
 
 import (
 	"context"
+	"fmt"
+	gopath "path"
 	"runtime"
+	"sync"
+	"time"
 
 	"github.com/hugelgupf/p9/p9"
 	"github.com/hugelgupf/p9/unimplfs"
+	cid "github.com/ipfs/go-cid"
 	nodeopts "github.com/ipfs/go-ipfs/plugin/plugins/filesystem/nodes/options"
 	fsutils "github.com/ipfs/go-ipfs/plugin/plugins/filesystem/utils"
 	logging "github.com/ipfs/go-log"
 	coreiface "github.com/ipfs/interface-go-ipfs-core"
+	coreoptions "github.com/ipfs/interface-go-ipfs-core/options"
+	corepath "github.com/ipfs/interface-go-ipfs-core/path"
 )
 
 var _ p9.File = (*KeyFS)(nil)
@@ -20,10 +27,24 @@ type KeyFS struct {
 	p9.DefaultWalkGetAttr
 
 	IPFSBase
+	KeyFSFileMeta
+
+	// shared roots across all FS instances
+	sharedLock *sync.Mutex                // should be held when accessing the root map
+	mroots     map[string]fsutils.WalkRef // map["key"]*MFS{}
+}
+
+type KeyFSFileMeta struct {
+	ents []p9.Dirent
+	// TODO support key as a file too
+	// keyFile KeyIO
 }
 
 func KeyFSAttacher(ctx context.Context, core coreiface.CoreAPI, ops ...nodeopts.AttachOption) p9.Attacher {
-	kd := &KeyFS{IPFSBase: newIPFSBase(ctx, "/keyfs", core, ops...)}
+	kd := &KeyFS{
+		IPFSBase: newIPFSBase(ctx, "/keyfs", core, ops...),
+		mroots:   make(map[string]fsutils.WalkRef),
+	}
 	kd.qid.Type = p9.TypeDir
 	kd.meta.Mode, kd.metaMask.Mode = p9.ModeDirectory|IRXA|0220, true
 
@@ -59,13 +80,36 @@ func (kd *KeyFS) Attach() (p9.File, error) {
 	return newFid, nil
 }
 
-func (kd *KeyFS) Open(mode p9.OpenFlags) (p9.QID, uint32, error) { return *kd.qid, 0, nil }
-func (kd *KeyFS) Close() error                                   { return kd.IPFSBase.close() }
+func (kd *KeyFS) Open(mode p9.OpenFlags) (p9.QID, uint32, error) {
+	kd.Logger.Debugf("Open")
 
-// temporary stub to allow forwarding requests on empty directory
-// will contain keys later
+	ctx, cancel := kd.callCtx()
+	defer cancel()
+
+	ents, err := getKeys(ctx, kd.core)
+	if err != nil {
+		kd.Logger.Errorf("Open hit: %s", err)
+		cancel()
+		return *kd.qid, 0, err
+	}
+	kd.ents = ents
+
+	kd.Logger.Errorf("Open ret: %v", kd.ents)
+
+	return *kd.qid, 0, nil
+
+}
+func (kd *KeyFS) Close() error {
+	kd.ents = nil
+	return kd.IPFSBase.close()
+}
+
 func (kd *KeyFS) Readdir(offset uint64, count uint32) ([]p9.Dirent, error) {
-	return nil, nil
+	if kd.ents == nil {
+		return nil, fmt.Errorf("directory %q is not open for reading", kd.String())
+	}
+
+	return flatReaddir(kd.ents, offset, count)
 }
 
 /* WalkRef relevant */
@@ -75,17 +119,69 @@ func (kd *KeyFS) Fork() (fsutils.WalkRef, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &KeyFS{IPFSBase: base}, nil
+
+	newFid := &KeyFS{
+		IPFSBase: base,
+		mroots:   kd.mroots,
+	}
+	return newFid, nil
 }
 
 // KeyFS forks the IPFS root that was set during construction
 // and calls step on it rather than itself
-func (kd *KeyFS) Step(name string) (fsutils.WalkRef, error) {
-	newFid, err := kd.proxy.Fork()
-	if err != nil {
+func (kd *KeyFS) Step(keyName string) (fsutils.WalkRef, error) {
+	callCtx, cancel := kd.callCtx()
+	defer cancel()
+
+	key, err := getKey(callCtx, keyName, kd.core)
+	switch err {
+	default:
+		// unexpected failure
 		return nil, err
+
+	case errKeyNotInStore:
+		// proxy non-keyed requests to an IPNS derivative
+		proxyRef, err := kd.proxy.Fork()
+		if err != nil {
+			return nil, err
+		}
+		return proxyRef.Step(keyName)
+
+	case nil:
+		// appropriate roots that are names of keys we own
+		mfsNode, ok := kd.mroots[keyName]
+		if !ok {
+			// init
+			corePath, err := kd.core.ResolvePath(callCtx, key.Path())
+			if err != nil {
+				return nil, err
+			}
+
+			//TODO: check key target's type; MFS for dirs, UnixIO for files
+			cid := corePath.Cid()
+			opts := []nodeopts.AttachOption{
+				nodeopts.Parent(kd),
+				nodeopts.MFSPublish(ipnsPublisher(key.Name(), offlineAPI(kd.core).Name())),
+				nodeopts.MFSRoot(&cid),
+				nodeopts.Logger(logging.Logger("IPNS-Key")),
+			}
+
+			mRoot, err := MFSAttacher(kd.filesystemCtx, kd.core, opts...).Attach()
+			if err != nil {
+				return nil, err
+			}
+
+			mfsNode = mRoot.(fsutils.WalkRef)
+			kd.mroots[keyName] = mfsNode
+
+			// TODO: validate this
+			runtime.SetFinalizer(mfsNode, func(wr fsutils.WalkRef) {
+				delete(kd.mroots, keyName)
+			})
+		}
+
+		return mfsNode, nil
 	}
-	return newFid.Step(name)
 }
 
 func (kd *KeyFS) CheckWalk() error                    { return kd.Base.checkWalk() }
@@ -103,4 +199,82 @@ func (kd *KeyFS) Walk(names []string) ([]p9.QID, p9.File, error) {
 
 func (kd *KeyFS) GetAttr(req p9.AttrMask) (p9.QID, p9.AttrMask, p9.Attr, error) {
 	return kd.Base.getAttr(req)
+}
+
+func getKeys(ctx context.Context, core coreiface.CoreAPI) ([]p9.Dirent, error) {
+	keys, err := core.Key().List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	ents := make([]p9.Dirent, 0, len(keys))
+
+	// temporary conversion storage
+	attr := &p9.Attr{}
+	requestType := p9.AttrMask{Mode: true}
+
+	var offset uint64 = 1
+	for _, key := range keys {
+		//
+		ipldNode, err := core.ResolveNode(ctx, key.Path())
+		if err != nil {
+			//FIXME: bug in either the CoreAPI, http client, or somewhere else
+			//if err == coreiface.ErrResolveFailed {
+			//HACK:
+			if err.Error() == coreiface.ErrResolveFailed.Error() {
+				continue // skip unresolvable keys (typical when a key exists but hasn't been published to
+			}
+			return nil, err
+		}
+		if _, err = ipldStat(ctx, attr, ipldNode, requestType); err != nil {
+			return nil, err
+		}
+
+		ents = append(ents, p9.Dirent{
+			//Name:   gopath.Base(key.Path().String()),
+			Name:   gopath.Base(key.Name()),
+			Offset: offset,
+			QID: p9.QID{
+				Type: attr.Mode.QIDType(),
+				Path: cidToQPath(ipldNode.Cid()),
+			},
+		})
+		offset++
+	}
+	return ents, nil
+}
+
+func ipnsPublisher(keyName string, nameAPI coreiface.NameAPI) func(context.Context, cid.Cid) error {
+	return func(ctx context.Context, rootCid cid.Cid) error {
+		callCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		_, err := nameAPI.Publish(callCtx, corepath.IpfsPath(rootCid), coreoptions.Name.Key(keyName), coreoptions.Name.AllowOffline(true))
+		return err
+	}
+}
+
+func getKey(ctx context.Context, keyName string, core coreiface.CoreAPI) (coreiface.Key, error) {
+	if keyName == "self" {
+		return core.Key().Self(ctx)
+	}
+
+	keys, err := core.Key().List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var key coreiface.Key
+	for _, curKey := range keys {
+		if curKey.Name() == keyName {
+			key = curKey
+			break
+		}
+	}
+
+	if key == nil {
+		//return nil, fmt.Errorf(errFmtExternalWalk, keyName)
+		return nil, errKeyNotInStore
+	}
+
+	return key, nil
 }

--- a/plugin/plugins/filesystem/nodes/keyfs.go
+++ b/plugin/plugins/filesystem/nodes/keyfs.go
@@ -72,7 +72,11 @@ func KeyFSAttacher(ctx context.Context, core coreiface.CoreAPI, ops ...nodeopts.
 func (kd *KeyFS) Attach() (p9.File, error) {
 	kd.Logger.Debugf("Attach")
 
-	newFid := &KeyFS{IPFSBase: kd.IPFSBase.clone()}
+	newFid := &KeyFS{
+		IPFSBase: kd.IPFSBase.clone(),
+		mroots:   kd.mroots,
+	}
+
 	// set new fs context
 	if err := newFid.forkFilesystem(); err != nil {
 		return nil, err

--- a/plugin/plugins/filesystem/nodes/mfs.go
+++ b/plugin/plugins/filesystem/nodes/mfs.go
@@ -1,0 +1,411 @@
+package fsnodes
+
+import (
+	"context"
+	"fmt"
+	"io"
+	gopath "path"
+	"time"
+
+	"github.com/hugelgupf/p9/p9"
+	"github.com/hugelgupf/p9/unimplfs"
+	cid "github.com/ipfs/go-cid"
+	nodeopts "github.com/ipfs/go-ipfs/plugin/plugins/filesystem/nodes/options"
+	fsutils "github.com/ipfs/go-ipfs/plugin/plugins/filesystem/utils"
+	dag "github.com/ipfs/go-merkledag"
+	"github.com/ipfs/go-mfs"
+	coreiface "github.com/ipfs/interface-go-ipfs-core"
+)
+
+var _ p9.File = (*MFS)(nil)
+var _ fsutils.WalkRef = (*MFS)(nil)
+
+// TODO: break this up into 2 file systems?
+// MFS + MFS Overlay?
+// TODO: docs
+type MFS struct {
+	unimplfs.NoopFile
+	p9.DefaultWalkGetAttr
+
+	IPFSBase
+	MFSFileMeta
+
+	//ref   uint                 //TODO: rename, root refcount
+	//key   coreiface.Key        // optional value, if set, publish to IPNS key on MFS change
+	//roots map[string]*mfs.Root //share the same mfs root across calls
+	mroot *mfs.Root
+}
+
+type MFSFileMeta struct {
+	file      mfs.FileDescriptor
+	directory *mfs.Directory
+}
+
+func MFSAttacher(ctx context.Context, core coreiface.CoreAPI, ops ...nodeopts.AttachOption) p9.Attacher {
+	options := nodeopts.AttachOps(ops...)
+
+	mroot, err := cidToMFSRoot(ctx, options.MFSRoot, core, options.MFSPublish)
+	if err != nil {
+		panic(err)
+	}
+
+	md := &MFS{
+		IPFSBase: newIPFSBase(ctx, "/ipld", core, ops...),
+		mroot:    mroot,
+	}
+	md.meta.Mode, md.metaMask.Mode = p9.ModeDirectory|IRXA|0220, true
+
+	return md
+}
+
+func (md *MFS) Fork() (fsutils.WalkRef, error) {
+	base, err := md.IPFSBase.fork()
+	if err != nil {
+		return nil, err
+	}
+
+	newFid := &MFS{
+		IPFSBase: base,
+		mroot:    md.mroot,
+	}
+	return newFid, nil
+
+}
+
+func (md *MFS) Attach() (p9.File, error) {
+	md.Logger.Debugf("Attach")
+
+	newFid := new(MFS)
+	*newFid = *md
+
+	return newFid, nil
+}
+
+func (md *MFS) GetAttr(req p9.AttrMask) (p9.QID, p9.AttrMask, p9.Attr, error) {
+	md.Logger.Debugf("GetAttr path: %s", md.StringPath())
+	md.Logger.Debugf("%p", md)
+
+	callCtx, cancel := md.callCtx()
+	defer cancel()
+
+	filled, err := mfsAttr(callCtx, md.meta, md.mroot, p9.AttrMaskAll, md.Trail...)
+	if err != nil {
+		return *md.qid, filled, *md.meta, err
+	}
+
+	md.meta.Mode |= IRXA | 0220
+	if req.RDev {
+		md.meta.RDev, filled.RDev = dMemory, true
+	}
+
+	return *md.qid, filled, *md.meta, nil
+}
+
+func (md *MFS) Walk(names []string) ([]p9.QID, p9.File, error) {
+	md.Logger.Debugf("Walk names: %v", names)
+	md.Logger.Debugf("Walk myself: %q:{%d}", md.StringPath(), md.ninePath())
+
+	return fsutils.Walker(md, names)
+}
+
+func (md *MFS) Open(mode p9.OpenFlags) (p9.QID, uint32, error) {
+	md.Logger.Debugf("Open %q {Mode:%v OSFlags:%v, String:%s}", md.StringPath(), mode.Mode(), mode.OSFlags(), mode.String())
+	md.Logger.Debugf("%p", md)
+
+	if md.mroot == nil {
+		return *md.qid, 0, fmt.Errorf("TODO: message; root not set")
+	}
+
+	//TODO: current: lookup -> mfsnoode -> md.file | md.directory = mfsNode.open(fsctx)
+
+	mNode, err := mfs.Lookup(md.mroot, gopath.Join(md.Trail...))
+	if err != nil {
+		return *md.qid, 0, err
+	}
+
+	// handle directories
+	if md.meta.Mode.IsDir() {
+		dir, ok := mNode.(*mfs.Directory)
+		if !ok {
+			return *md.qid, 0, fmt.Errorf("type mismatch %q is %T not a directory", md.StringPath(), mNode)
+		}
+		md.directory = dir
+	} else {
+		mFile, ok := mNode.(*mfs.File)
+		if !ok {
+			return *md.qid, 0, fmt.Errorf("type mismatch %q is %T not a file", md.StringPath(), mNode)
+		}
+
+		openFile, err := mFile.Open(mfs.Flags{Read: true, Write: true})
+		if err != nil {
+			return *md.qid, 0, err
+		}
+		s, err := openFile.Size()
+		if err != nil {
+			return *md.qid, 0, err
+		}
+
+		md.file = openFile
+		md.meta.Size, md.metaMask.Size = uint64(s), true
+	}
+
+	return *md.qid, ipfsBlockSize, nil
+}
+
+func (md *MFS) Readdir(offset uint64, count uint32) ([]p9.Dirent, error) {
+	md.Logger.Debugf("Readdir %d %d", offset, count)
+
+	if md.directory == nil {
+		return nil, fmt.Errorf("directory %q is not open for reading", md.StringPath())
+	}
+
+	//TODO: resetable context; for { ...; ctx.reset() }
+	callCtx, cancel := context.WithCancel(md.filesystemCtx)
+	defer cancel()
+
+	ents := make([]p9.Dirent, 0)
+
+	var index uint64
+	var done bool
+	err := md.directory.ForEachEntry(callCtx, func(nl mfs.NodeListing) error {
+		if done {
+			cancel()
+			return nil
+		}
+
+		if index < offset {
+			index++ //skip
+			return nil
+		}
+
+		ent, err := mfsEntTo9Ent(nl)
+		if err != nil {
+			return err
+		}
+
+		ent.Offset = index + 1
+
+		ents = append(ents, ent)
+		if len(ents) == int(count) {
+			done = true
+		}
+
+		index++
+		return nil
+	})
+
+	return ents, err
+}
+
+func (md *MFS) ReadAt(p []byte, offset uint64) (int, error) {
+	const (
+		readAtFmt    = "ReadAt {%d/%d}%q"
+		readAtFmtErr = readAtFmt + ": %s"
+	)
+
+	if md.file == nil {
+		err := fmt.Errorf("file is not open for reading")
+		md.Logger.Errorf(readAtFmtErr, offset, md.meta.Size, md.StringPath(), err)
+		return 0, err
+	}
+
+	if offset >= md.meta.Size {
+		//NOTE [styx]: If the offset field is greater than or equal to the number of bytes in the file, a count of zero will be returned.
+		return 0, io.EOF
+	}
+
+	if _, err := md.file.Seek(int64(offset), io.SeekStart); err != nil {
+		md.Logger.Errorf(readAtFmtErr, offset, md.meta.Size, md.StringPath(), err)
+		return 0, err
+	}
+
+	//TODO: remove, debug
+
+	nbytes, err := md.file.Read(p)
+	if err != nil {
+		md.Logger.Errorf(readAtFmtErr, offset, md.meta.Size, md.StringPath(), err)
+	}
+
+	return nbytes, err
+	//
+
+	//return md.file.Read(p)
+}
+
+func (md *MFS) SetAttr(valid p9.SetAttrMask, attr p9.SetAttr) error {
+	md.Logger.Debugf("SetAttr %v %v", valid, attr)
+	md.Logger.Debugf("%p", md)
+
+	if valid.Size && attr.Size < md.meta.Size {
+		if md.file == nil {
+			err := fmt.Errorf("file %q is not open, cannot change size", md.StringPath())
+			md.Logger.Error(err)
+			return err
+		}
+
+		if err := md.file.Truncate(int64(attr.Size)); err != nil {
+			return err
+		}
+	}
+
+	md.meta.Apply(valid, attr)
+	return nil
+}
+
+func (md *MFS) WriteAt(p []byte, offset uint64) (int, error) {
+	const (
+		readAtFmt    = "WriteAt {%d/%d}%q"
+		readAtFmtErr = readAtFmt + ": %s"
+	)
+	if md.file == nil {
+		err := fmt.Errorf("file is not open for writing")
+		md.Logger.Errorf(readAtFmtErr, offset, md.meta.Size, md.StringPath(), err)
+		return 0, err
+	}
+
+	//TODO: remove, debug
+
+	nbytes, err := md.file.WriteAt(p, int64(offset))
+	if err != nil {
+		md.Logger.Errorf(readAtFmtErr, offset, md.meta.Size, md.StringPath(), err)
+	}
+
+	return nbytes, err
+	//
+
+	//return md.file.WriteAt(p, int64(offset))
+}
+
+func (md *MFS) Close() error {
+	md.Logger.Debugf("closing: %q:{%d}", md.StringPath(), md.ninePath())
+
+	if md.file != nil {
+		if err := md.file.Close(); err != nil {
+			md.Logger.Error(err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+/*
+{
+    Base: {
+	coreNamespace: `/ipld`,
+	Trail: []string{"folder", "file.txt"}
+    }
+    mroot: fromCid(`QmVuDpaFj55JnUH7UYxTAydx6ayrs2cB3Gb7cdPr61wLv5`)
+}
+=>
+`/ipld/QmVuDpaFj55JnUH7UYxTAydx6ayrs2cB3Gb7cdPr61wLv5/folder/file.txt`
+*/
+func (md *MFS) StringPath() string {
+	rootNode, err := md.mroot.GetDirectory().GetNode()
+	if err != nil {
+		panic(err)
+	}
+	return gopath.Join(append([]string{md.coreNamespace, rootNode.Cid().String()}, md.Trail...)...)
+}
+
+func mfsAttr(ctx context.Context, attr *p9.Attr, mroot *mfs.Root, req p9.AttrMask, names ...string) (p9.AttrMask, error) {
+	mfsNode, err := mfs.Lookup(mroot, gopath.Join(names...))
+	if err != nil {
+		return p9.AttrMask{}, err
+	}
+
+	ipldNode, err := mfsNode.GetNode()
+	if err != nil {
+		return p9.AttrMask{}, err
+	}
+
+	return ipldStat(ctx, attr, ipldNode, req)
+}
+
+func mfsToQid(ctx context.Context, mroot *mfs.Root, names ...string) (p9.QID, error) {
+	mNode, err := mfs.Lookup(mroot, gopath.Join(names...))
+	if err != nil {
+		return p9.QID{}, err
+	}
+
+	t, err := mfsTypeToNineType(mNode.Type())
+	if err != nil {
+		return p9.QID{}, err
+	}
+
+	ipldNode, err := mNode.GetNode()
+	if err != nil {
+		return p9.QID{}, err
+	}
+
+	return p9.QID{
+		Type: t,
+		Path: cidToQPath(ipldNode.Cid()),
+	}, nil
+}
+
+func (md *MFS) Step(name string) (fsutils.WalkRef, error) {
+	callCtx, cancel := md.callCtx()
+	defer cancel()
+
+	breadCrumb := append(md.Trail, name)
+	qid, err := mfsToQid(callCtx, md.mroot, breadCrumb...)
+	if err != nil {
+		return nil, err
+	}
+
+	// set on success; we stepped
+	md.Trail = breadCrumb
+	*md.qid = qid
+	return md, nil
+}
+
+/*
+func (md *MFS) RootPath(keyName string, components ...string) (corepath.Path, error) {
+	if keyName == "" {
+		return nil, fmt.Errorf("no path key was provided")
+	}
+
+	rootCid, err := cid.Decode(keyName)
+	if err != nil {
+		return nil, err
+	}
+
+	return corepath.Join(corepath.IpldPath(rootCid), components...), nil
+}
+
+func (md *MFS) ResolvedPath(names ...string) (corepath.Path, error) {
+	callCtx, cancel := md.callCtx()
+	defer cancel()
+
+	return md.core.ResolvePath(callCtx, md.KeyPath(names[0], names[1:]...))
+
+	corePath = corepath.IpldPath(md.Tail[0])
+	return md.core.ResolvePath(callCtx, corepath.Join(corePath, append(md.Tail[1:], names)...))
+}
+*/
+
+func cidToMFSRoot(ctx context.Context, rootCid *cid.Cid, core coreiface.CoreAPI, publish mfs.PubFunc) (*mfs.Root, error) {
+	callCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	ipldNode, err := core.Dag().Get(callCtx, *rootCid)
+	if err != nil {
+		return nil, err
+	}
+
+	pbNode, ok := ipldNode.(*dag.ProtoNode)
+	if !ok {
+		return nil, fmt.Errorf("%q has incompatible type %T", rootCid.String(), ipldNode)
+	}
+
+	return mfs.NewRoot(ctx, core.Dag(), pbNode, publish)
+}
+
+func (md *MFS) CheckWalk() error                    { return md.Base.checkWalk() }
+func (md *MFS) Backtrack() (fsutils.WalkRef, error) { return md.IPFSBase.backtrack(md) }
+func (md *MFS) QID() (p9.QID, error) {
+	callCtx, cancel := md.callCtx()
+	defer cancel()
+
+	return coreToQid(callCtx, md.CorePath(), md.core)
+}

--- a/plugin/plugins/filesystem/nodes/mfs.go
+++ b/plugin/plugins/filesystem/nodes/mfs.go
@@ -569,3 +569,11 @@ func (md *MFS) Mknod(name string, mode p9.FileMode, major uint32, minor uint32, 
 
 	return newRef.QID()
 }
+
+func (md *MFS) UnlinkAt(name string, flags uint32) error {
+	dir, err := md.getDirectory()
+	if err != nil {
+		return err
+	}
+	return dir.Unlink(name)
+}

--- a/plugin/plugins/filesystem/nodes/mfs.go
+++ b/plugin/plugins/filesystem/nodes/mfs.go
@@ -310,6 +310,9 @@ func (md *MFS) Close() error {
 
 	md.file = nil
 	md.directory = nil
+	if md.mroot != nil {
+		return md.mroot.Flush()
+	}
 	return nil
 }
 

--- a/plugin/plugins/filesystem/nodes/options/options.go
+++ b/plugin/plugins/filesystem/nodes/options/options.go
@@ -13,7 +13,7 @@ type AttachOptions struct {
 	Parent     fsutils.WalkRef     // node directly behind self
 	Logger     logging.EventLogger // what subsystem you are
 	Process    goprocess.Process   // TODO: I documented this somewhere else
-	MFSRoot    *cid.Cid            // required when attaching to MFS
+	MFSRoot    cid.Cid             // required when attaching to MFS
 	MFSPublish mfs.PubFunc
 }
 
@@ -50,7 +50,7 @@ func Process(p goprocess.Process) AttachOption {
 	}
 }
 
-func MFSRoot(rcid *cid.Cid) AttachOption {
+func MFSRoot(rcid cid.Cid) AttachOption {
 	return func(ops *AttachOptions) {
 		ops.MFSRoot = rcid
 	}

--- a/plugin/plugins/filesystem/nodes/utils.go
+++ b/plugin/plugins/filesystem/nodes/utils.go
@@ -145,6 +145,8 @@ func unixfsTypeTo9Type(ut unixpb.Data_DataType) (p9.FileMode, error) {
 		return p9.ModeSymlink, nil
 	case unixpb.Data_File:
 		return p9.ModeRegular, nil
+	case unixpb.Data_Raw: //TODO [investigate]: the result of `mfs.WriteAt` produces a file of this type if the contents are small enough
+		return p9.ModeRegular, nil
 	default:
 		return p9.ModeRegular, fmt.Errorf("UFS data type %q was not expected, treating as regular file", ut)
 	}


### PR DESCRIPTION
See: https://github.com/ipfs/go-ipfs/pull/6612
This is the same base, but intents to extend support to handle write operations.

Currently WIP.
Notable difference will be within the KeyFS and MFS